### PR TITLE
Багфикс остановки на астероиде

### DIFF
--- a/astrobox/core.py
+++ b/astrobox/core.py
@@ -243,7 +243,11 @@ class Drone(Unit):
         return self.scene.asteroids
 
     def on_stop_at_target(self, target):
-        nearest_asteroid = min(self.asteroids, key=lambda asteroid: self.distance_to(asteroid))
+        nearest_asteroid = (
+            min(self.asteroids, key=lambda asteroid: self.distance_to(asteroid))
+            if self.asteroids else
+            None
+        )
         if nearest_asteroid and self.near(nearest_asteroid):
             self.on_stop_at_asteroid(nearest_asteroid)
             return

--- a/astrobox/core.py
+++ b/astrobox/core.py
@@ -243,10 +243,10 @@ class Drone(Unit):
         return self.scene.asteroids
 
     def on_stop_at_target(self, target):
-        for asteroid in self.asteroids:
-            if asteroid.near(target):
-                self.on_stop_at_asteroid(asteroid)
-                return
+        nearest_asteroid = min(self.asteroids, key=lambda asteroid: self.distance_to(asteroid))
+        if nearest_asteroid and self.near(nearest_asteroid):
+            self.on_stop_at_asteroid(nearest_asteroid)
+            return
         else:
             for ship in self.scene.motherships:
                 if ship.near(target):


### PR DESCRIPTION
Когда астероиды расположены очень близко, дрону передаётся не тот астероид, на котором он остановился, а соседний.
Т. к. в классе загрузки ресурсов CargoTransition (astrobox/cargo.py), в методе game_step выполняется проверка:
    if self.cargo_to.owner.distance_to(self.cargo_from.owner) >= self.__distance:
то получается, что метод near срабатывает на дистанции 44 (радиус дрона), а self.__distance в проверке загрузки равно 10. И загрузка сразу прерывается, т. к. дрон остановился на соседнем астероиде, расстояние до которого больше 10, но меньше 44.